### PR TITLE
Workaround for older model that doesnt specify required param

### DIFF
--- a/src/fastapi_app/query_rewriter.py
+++ b/src/fastapi_app/query_rewriter.py
@@ -18,7 +18,7 @@ def build_search_function() -> list[ChatCompletionToolParam]:
                     "properties": {
                         "search_query": {
                             "type": "string",
-                            "description": "Query string to use for full text search, e.g. 'red shoes'. This required parameter must always be specified.",
+                            "description": "Query string to use for full text search, e.g. 'red shoes'.",
                         },
                         "price_filter": {
                             "type": "object",

--- a/src/fastapi_app/query_rewriter.py
+++ b/src/fastapi_app/query_rewriter.py
@@ -18,7 +18,7 @@ def build_search_function() -> list[ChatCompletionToolParam]:
                     "properties": {
                         "search_query": {
                             "type": "string",
-                            "description": "Query string to use for full text search, e.g. 'red shoes'",
+                            "description": "Query string to use for full text search, e.g. 'red shoes'. This required parameter must always be specified.",
                         },
                         "price_filter": {
                             "type": "object",
@@ -56,7 +56,7 @@ def build_search_function() -> list[ChatCompletionToolParam]:
     ]
 
 
-def extract_search_arguments(chat_completion: ChatCompletion):
+def extract_search_arguments(original_user_query: str, chat_completion: ChatCompletion):
     response_message = chat_completion.choices[0].message
     search_query = None
     filters = []
@@ -67,7 +67,8 @@ def extract_search_arguments(chat_completion: ChatCompletion):
             function = tool.function
             if function.name == "search_database":
                 arg = json.loads(function.arguments)
-                search_query = arg.get("search_query")
+                # Even though its required, search_query is not always specified
+                search_query = arg.get("search_query", original_user_query)
                 if "price_filter" in arg and arg["price_filter"]:
                     price_filter = arg["price_filter"]
                     filters.append(

--- a/src/fastapi_app/query_rewriter.py
+++ b/src/fastapi_app/query_rewriter.py
@@ -18,7 +18,7 @@ def build_search_function() -> list[ChatCompletionToolParam]:
                     "properties": {
                         "search_query": {
                             "type": "string",
-                            "description": "Query string to use for full text search, e.g. 'red shoes'.",
+                            "description": "Query string to use for full text search, e.g. 'red shoes'",
                         },
                         "price_filter": {
                             "type": "object",

--- a/src/fastapi_app/rag_advanced.py
+++ b/src/fastapi_app/rag_advanced.py
@@ -65,7 +65,7 @@ class AdvancedRAGChat:
             tool_choice="auto",
         )
 
-        query_text, filters = extract_search_arguments(chat_completion)
+        query_text, filters = extract_search_arguments(original_user_query, chat_completion)
 
         # Retrieve relevant items from the database with the GPT optimized query
         results = await self.searcher.search_and_embed(


### PR DESCRIPTION
## Purpose

It appears that gpt-3.5-turbo 0613 doesn't specify required parameters as reliably as newer models, especially with other parameters being specified, which was breaking calls that involved filters. So this change means it will always default to the original user_query if no search_query was found in the parameters.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

:( no tests ye