### PR TITLE
Try removing clear=True to fix Playwright tests on Windows

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -76,7 +76,7 @@ jobs:
           run: python3 -m pytest -s -vv --cov --cov-fail-under=85
         - name: Run E2E tests with Playwright
           id: e2e
-          if: runner.os != 'Windows'
+          #if: runner.os != 'Windows'
           run: |
             playwright install chromium --with-deps
             python3 -m pytest tests/e2e.py --tracing=retain-on-failure

--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -76,7 +76,6 @@ jobs:
           run: python3 -m pytest -s -vv --cov --cov-fail-under=85
         - name: Run E2E tests with Playwright
           id: e2e
-          #if: runner.os != 'Windows'
           run: |
             playwright install chromium --with-deps
             python3 -m pytest tests/e2e.py --tracing=retain-on-failure

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def monkeypatch_session():
 @pytest.fixture(scope="session")
 def mock_session_env(monkeypatch_session):
     """Mock the environment variables for testing."""
-    with mock.patch.dict(os.environ, clear=True):
+    with mock.patch.dict(os.environ):
         # Database
         monkeypatch_session.setenv("POSTGRES_HOST", POSTGRES_HOST)
         monkeypatch_session.setenv("POSTGRES_USERNAME", POSTGRES_USERNAME)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,9 @@ def monkeypatch_session():
 @pytest.fixture(scope="session")
 def mock_session_env(monkeypatch_session):
     """Mock the environment variables for testing."""
+    # Note that this does *not* clear existing env variables by default-
+    # we used to specify clear=True but this caused issues with Playwright tests
+    # https://github.com/microsoft/playwright-python/issues/2506
     with mock.patch.dict(os.environ):
         # Database
         monkeypatch_session.setenv("POSTGRES_HOST", POSTGRES_HOST)


### PR DESCRIPTION
## Purpose

Per suggestion in https://github.com/microsoft/playwright-python/issues/2506

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [x] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` manually on my code.
