### PR TITLE
Update entrypoint.sh - Add --host 0.0.0.0 to Uvicorn execution

### DIFF
--- a/src/backend/entrypoint.sh
+++ b/src/backend/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-python3 -m uvicorn "fastapi_app:create_app" --factory --port 8000
+python3 -m uvicorn "fastapi_app:create_app" --factory --host 0.0.0.0 --port 8000


### PR DESCRIPTION
Fixes deployment error:
"The TargetPort 8000 is bound to an inaccessible loopback IP address, bind to a non-loopback IP address instead."