### PR TITLE
allow setting AZURE_OPENAI_LOCATION in env

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -17,6 +17,9 @@
       "runningOnGh": {
         "value": "${GITHUB_ACTIONS}"
       },
+      "openAILocation": {
+        "value": "${AZURE_OPENAI_LOCATION}"
+      },
       "deployAzureOpenAI": {
         "value": "${DEPLOY_AZURE_OPENAI=true}"
       },


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Unblock azd up --no-prompt by setting AZURE_OPENAI_LOCATION in env.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[x] No
```

## Type of change

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A

* PF tested with a brand new env, it still prompts for location in that case.