### PR TITLE
Add entra auth

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -3,8 +3,18 @@ name: App Tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
+      - ".azdo/**"
+      - ".devcontainer/**"
+      - ".github/**"
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
+      - ".azdo/**"
+      - ".devcontainer/**"
+      - ".github/**"
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Further documentation is available in the `docs/` folder:
 * [Understanding the RAG flow](docs/rag_flow.md)
 * [Customizing the data](docs/customize_data.md)
 * [Deploying with existing resources](docs/deploy_existing.md)
+* [Using Entra auth with PostgreSQL tools](docs/using_entra_auth.md)
 * [Monitoring with Azure Monitor](docs/monitoring.md)
 * [Load testing](docs/loadtesting.md)
 

--- a/docs/using_entra_auth.md
+++ b/docs/using_entra_auth.md
@@ -1,0 +1,41 @@
+# Using Entra auth with PostgreSQL tools
+
+To follow security best practices, this project is setup to use passwordless authentication with the Azure Database for PostgreSQL Flexible Server. This means that you can't connect to the database with a password, but instead need to use a token associated with a Microsoft Entra user. Locally, the user should be your own Azure account, whichever account was used to run `azd up`. In production, the user will be the managed identity assigned to the Azure Container App.
+
+## Using psql with Entra auth
+
+1. Make sure you are logged into the Azure Developer CLI with the same account that was used to run `azd up`.
+
+    ```shell
+    azd auth login
+    ```
+
+    If you used a non-default tenant to run `azd up`, you may need to specify the tenant ID:
+
+    ```shell
+    azd auth login --tenant-id {tenant_id}
+    ```
+
+2. Generate a token for the Azure Database for PostgreSQL Flexible Server.
+
+    ```shell
+    azd auth token --scope https://ossrdbms-aad.database.windows.net/.default --tenant-id 1bd0d125-6c64-49d1-af0d-88fa60e18074 --output json
+    ```
+
+    This will output JSON with a token that you can use to connect to the database.
+
+3. Set the `PGPASSWORD` environment variable to the token.
+
+    ```shell
+    export PGPASSWORD={token}
+    ```
+
+    If you are using a different shell, you may need to use a different syntax to set the environment variable.
+
+4. Connect to the database with `psql`, using the `POSTGRES_HOST`, `POSTGRES_USERNAME`, and `POSTGRES_DATABASE` values from the current `azd` environment.
+
+    ```shell
+    psql -h $(azd env get-value POSTGRES_HOST) -U $(azd env get-value POSTGRES_USERNAME) -d $(azd env get-value POSTGRES_DATABASE) -p 5432
+    ```
+
+5. In psql, use `\d` to list the tables. When you `SELECT` from a table, select only the columns you're interested in, to avoid rendering the vector embeddings in the terminal.

--- a/docs/using_entra_auth.md
+++ b/docs/using_entra_auth.md
@@ -19,10 +19,16 @@ To follow security best practices, this project is setup to use passwordless aut
 2. Generate a token for the Azure Database for PostgreSQL Flexible Server.
 
     ```shell
-    azd auth token --scope https://ossrdbms-aad.database.windows.net/.default --tenant-id 1bd0d125-6c64-49d1-af0d-88fa60e18074 --output json
+    azd auth token --scope https://ossrdbms-aad.database.windows.net/.default --output json
     ```
 
-    This will output JSON with a token that you can use to connect to the database.
+    Once again, if you used a non-default tenant to run `azd up`, you may need to specify the tenant ID.
+
+    ```shell
+    azd auth token --scope https://ossrdbms-aad.database.windows.net/.default --tenant-id YOUR-TENANT-ID --output json
+    ```
+
+    This will output JSON with a token inside the "token" field. Copy the token.
 
 3. Set the `PGPASSWORD` environment variable to the token.
 


### PR DESCRIPTION
## Purpose

Adding page about Entra-based auth to PG tools. Will add PGadmin next.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A