### PR TITLE
Add pre_down scripts to delete GlobalStandard deployments

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -36,6 +36,15 @@ hooks:
             run: ./scripts/setup_postgres_database.sh;./scripts/setup_postgres_azurerole.sh;./scripts/setup_postgres_seeddata.sh
             interactive: true
             continueOnError: false
+    predown:
+      windows:
+        shell: pwsh
+        run: ./scripts/pre_down.ps1
+        continueOnError: true
+      posix:
+        shell: sh
+        run: ./scripts/pre_down.sh
+        continueOnError: true
 pipeline:
   variables:
     - DEPLOY_AZURE_OPENAI

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -444,6 +444,8 @@ output SERVICE_WEB_IMAGE_NAME string = web.outputs.SERVICE_WEB_IMAGE_NAME
 
 output OPENAI_CHAT_HOST string = openAIChatHost
 output OPENAI_EMBED_HOST string = openAIEmbedHost
+output AZURE_OPENAI_SERVICE string = deployAzureOpenAI ? openAI.outputs.name : ''
+output AZURE_OPENAI_RESOURCE_GROUP string = deployAzureOpenAI ? openAIResourceGroup.name : ''
 output AZURE_OPENAI_ENDPOINT string = !empty(azureOpenAIEndpoint)
   ? azureOpenAIEndpoint
   : (deployAzureOpenAI ? openAI.outputs.endpoint : '')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ filterwarnings = ["ignore::DeprecationWarning"]
 [[tool.mypy.overrides]]
 module = [
     "pgvector.*",
-    "evaltools.*"
+    "evaltools.*",
+    "dotenv_azd.*",
 ]
 ignore_missing_imports = true
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,3 +14,5 @@ pytest-snapshot
 locust
 git+https://github.com/Azure-Samples/ai-rag-chat-evaluator/@installable
 psycopg2
+azure-mgmt-cognitiveservices
+dotenv-azd

--- a/scripts/pre_down.ps1
+++ b/scripts/pre_down.ps1
@@ -1,0 +1,5 @@
+# Get the directory of the current script
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Run the Python script
+python "$scriptDir/pre-down.py"

--- a/scripts/pre_down.py
+++ b/scripts/pre_down.py
@@ -1,0 +1,54 @@
+import logging
+import os
+
+from azure.identity import AzureDeveloperCliCredential
+from azure.mgmt.cognitiveservices import CognitiveServicesManagementClient
+from dotenv_azd import load_azd_env
+
+logger = logging.getLogger("ragapp")
+
+
+def delete_deployments(resource_name: str, resource_group: str, subscription_id: str, tenant_id: str = None):
+    """
+    Delete all deployments for an Azure OpenAI resource
+    """
+    if tenant_id:
+        logger.info("Authenticating to Azure using Azure Developer CLI Credential for tenant %s", tenant_id)
+        azure_credential = AzureDeveloperCliCredential(tenant_id=tenant_id, process_timeout=60)
+    else:
+        logger.info("Authenticating to Azure using Azure Developer CLI Credential")
+        azure_credential = AzureDeveloperCliCredential(process_timeout=60)
+
+    # Initialize the Cognitive Services client
+    client = CognitiveServicesManagementClient(azure_credential, subscription_id=subscription_id)
+
+    # List all deployments
+    deployments = client.deployments.list(resource_group_name=resource_group, account_name=resource_name)
+
+    # Delete each deployment and wait for the operation to complete
+    for deployment in deployments:
+        deployment_name = deployment.name
+        if not deployment_name:
+            continue
+        poller = client.deployments.begin_delete(
+            resource_group_name=resource_group, account_name=resource_name, deployment_name=deployment_name
+        )
+        poller.result()
+        logger.info(f"Deployment {deployment_name} deleted successfully.")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.WARNING)
+    logger.setLevel(logging.INFO)
+    load_azd_env()
+
+    try:
+        resource_name = os.environ["AZURE_OPENAI_SERVICE"]
+        resource_group = os.environ["AZURE_OPENAI_RESOURCE_GROUP"]
+        subscription_id = os.environ["AZURE_SUBSCRIPTION_ID"]
+        tenant_id = os.environ["AZURE_TENANT_ID"]
+    except KeyError as e:
+        logger.error("Missing azd environment variable %s", e)
+        exit(1)
+
+    delete_deployments(resource_name, resource_group, subscription_id, tenant_id)

--- a/scripts/pre_down.py
+++ b/scripts/pre_down.py
@@ -8,7 +8,7 @@ from dotenv_azd import load_azd_env
 logger = logging.getLogger("ragapp")
 
 
-def delete_deployments(resource_name: str, resource_group: str, subscription_id: str, tenant_id: str = None):
+def delete_deployments(resource_name: str, resource_group: str, subscription_id: str, tenant_id: str | None = None):
     """
     Delete all deployments for an Azure OpenAI resource
     """

--- a/scripts/pre_down.sh
+++ b/scripts/pre_down.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status
-set -e
-
 . ./scripts/load_python_env.sh
 
 # Get the directory of the current script

--- a/scripts/pre_down.sh
+++ b/scripts/pre_down.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+. ./scripts/load_python_env.sh
+
+# Get the directory of the current script
+script_dir=$(dirname "$0")
+
+# Run the Python script with the retrieved values
+.venv/bin/python "$script_dir/pre_down.py" --subscription-id $subscription_id --resource-name $resource_name --resource-group $resource_group --tenant-id $tenant_id


### PR DESCRIPTION
## Purpose

Fixes #95 by adding pre-down scripts to delete GlobalStandard OpenAI deployments.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` manually on my code.
