### PR TITLE
Remove python versions for faster CI

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest-xlarge", "macos-13", "windows-latest"]
-        python_version: ["3.10", "3.11", "3.12"]
+        python_version: ["3.10"]
         exclude:
           - os: macos-latest-xlarge
             python_version: "3.10"


### PR DESCRIPTION
## Purpose

I will bring back 3.11, 3.12, and perhaps 3.13, after GitHub U workshop.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[X] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A