### PR TITLE
Fix for vector extension order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
+    "python.envFile": "",
     "files.exclude": {
         ".ruff_cache": true,
         ".pytest_cache": true,

--- a/src/backend/fastapi_app/postgres_engine.py
+++ b/src/backend/fastapi_app/postgres_engine.py
@@ -37,7 +37,10 @@ async def create_postgres_engine(*, host, username, database, password, sslmode,
     @event.listens_for(engine.sync_engine, "connect")
     def register_custom_types(dbapi_connection: AdaptedConnection, *args):
         logger.info("Registering pgvector extension...")
-        dbapi_connection.run_async(register_vector)
+        try:
+            dbapi_connection.run_async(register_vector)
+        except ValueError:
+            logger.warning("Could not register pgvector data type yet as vector extension has not been CREATEd")
 
     @event.listens_for(engine.sync_engine, "do_connect")
     def update_password_token(dialect, conn_rec, cargs, cparams):


### PR DESCRIPTION
## Purpose


Fixes issue with new env

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` manually on my code.
