### PR TITLE
Add seed parameter (optional) and custom evaluation metric for citations overlap

### DIFF
--- a/evals/eval_config.json
+++ b/evals/eval_config.json
@@ -8,7 +8,7 @@
             "use_advanced_flow": true,
             "top": 3,
             "retrieval_mode": "hybrid",
-            "temperature": 0.3
+            "temperature": 2.0
         }
     },
     "target_response_answer_jmespath": "message.content",

--- a/evals/eval_config.json
+++ b/evals/eval_config.json
@@ -1,14 +1,15 @@
 {
     "testdata_path": "ground_truth.jsonl",
     "results_dir": "results/experiment<TIMESTAMP>",
-    "requested_metrics": ["gpt_groundedness", "gpt_relevance", "answer_length", "latency", "citation_match"],
+    "requested_metrics": ["gpt_groundedness", "gpt_relevance", "answer_length", "latency", "citations_matched"],
     "target_url": "http://127.0.0.1:8000/chat",
     "target_parameters": {
         "overrides": {
             "use_advanced_flow": true,
             "top": 3,
             "retrieval_mode": "hybrid",
-            "temperature": 2.0
+            "temperature": 0.3,
+            "seed": 42
         }
     },
     "target_response_answer_jmespath": "message.content",

--- a/src/backend/fastapi_app/api_models.py
+++ b/src/backend/fastapi_app/api_models.py
@@ -28,6 +28,7 @@ class ChatRequestOverrides(BaseModel):
     retrieval_mode: RetrievalMode = RetrievalMode.HYBRID
     use_advanced_flow: bool = True
     prompt_template: str | None = None
+    seed: int | None = None
 
 
 class ChatRequestContext(BaseModel):

--- a/src/backend/fastapi_app/rag_advanced.py
+++ b/src/backend/fastapi_app/rag_advanced.py
@@ -35,7 +35,11 @@ class AdvancedRAGChat(RAGChatBase):
         self.chat_token_limit = get_token_limit(chat_model, default_to_minimum=True)
 
     async def generate_search_query(
-        self, original_user_query: str, past_messages: list[ChatCompletionMessageParam], query_response_token_limit: int
+        self,
+        original_user_query: str,
+        past_messages: list[ChatCompletionMessageParam],
+        query_response_token_limit: int,
+        seed: int | None = None,
     ) -> tuple[list[ChatCompletionMessageParam], Any | str | None, list]:
         """Generate an optimized keyword search query based on the chat history and the last question"""
 
@@ -63,6 +67,7 @@ class AdvancedRAGChat(RAGChatBase):
             n=1,
             tools=tools,
             tool_choice=tool_choice,
+            seed=seed,
         )
 
         query_text, filters = extract_search_arguments(original_user_query, chat_completion)
@@ -76,6 +81,7 @@ class AdvancedRAGChat(RAGChatBase):
             original_user_query=chat_params.original_user_query,
             past_messages=chat_params.past_messages,
             query_response_token_limit=500,
+            seed=chat_params.seed,
         )
 
         # Retrieve relevant rows from the database with the GPT optimized query
@@ -142,6 +148,7 @@ class AdvancedRAGChat(RAGChatBase):
             max_tokens=chat_params.response_token_limit,
             n=1,
             stream=False,
+            seed=chat_params.seed,
         )
 
         return RetrievalResponse(

--- a/src/backend/fastapi_app/rag_base.py
+++ b/src/backend/fastapi_app/rag_base.py
@@ -36,6 +36,7 @@ class RAGChatBase(ABC):
         return ChatParams(
             top=overrides.top,
             temperature=overrides.temperature,
+            seed=overrides.seed,
             retrieval_mode=overrides.retrieval_mode,
             use_advanced_flow=overrides.use_advanced_flow,
             response_token_limit=response_token_limit,

--- a/src/backend/fastapi_app/rag_simple.py
+++ b/src/backend/fastapi_app/rag_simple.py
@@ -90,6 +90,7 @@ class SimpleRAGChat(RAGChatBase):
             max_tokens=chat_params.response_token_limit,
             n=1,
             stream=False,
+            seed=chat_params.seed,
         )
 
         return RetrievalResponse(
@@ -130,6 +131,7 @@ class SimpleRAGChat(RAGChatBase):
             max_tokens=chat_params.response_token_limit,
             n=1,
             stream=True,
+            seed=chat_params.seed,
         )
 
         yield RetrievalResponseDelta(


### PR DESCRIPTION
## Purpose

This pull request introduces several changes to add a new metric for evaluating citation matches and to incorporate a random seed for reproducibility in various functions. The most important changes include adding the new `CitationsMatchedMetric` class, updating configuration files to include the new metric, and modifying functions to accept and use a seed parameter.

### New Metric Addition:

* [`evals/eval_config.json`](diffhunk://#diff-4adb0af781fab559b88e413b18255bc068739bc61d4cf39f137700ac43fb87eaL4-R12): Updated the `requested_metrics` to include `"citations_matched"` and added a `seed` parameter in `target_parameters`.
* [`evals/evaluate.py`](diffhunk://#diff-94211c0749af47fbe4014baa2813a32093b8d3a2ca04a84417f856b93dfe4074R4-R41): Added the `CitationsMatchedMetric` class to compute the percentage of citations matched between the response and the ground truth. Registered this new metric in the evaluation pipeline. [[1]](diffhunk://#diff-94211c0749af47fbe4014baa2813a32093b8d3a2ca04a84417f856b93dfe4074R4-R41) [[2]](diffhunk://#diff-94211c0749af47fbe4014baa2813a32093b8d3a2ca04a84417f856b93dfe4074R90)

### Seed Parameter for Reproducibility:

* [`src/backend/fastapi_app/api_models.py`](diffhunk://#diff-e1037e2ed701bbf6f6ad3b290b9b216178438bbd7ff20941a245ebf6c1b09f95R31): Added a `seed` field to the `ChatRequestOverrides` model.
* [`src/backend/fastapi_app/rag_advanced.py`](diffhunk://#diff-8d31d8c50430de6c312cd00676b2fe3698a3af518cc295995df2729ad20e7aafL38-R42): Modified multiple functions (`generate_search_query`, `prepare_context`, `answer`) to accept and use the `seed` parameter. [[1]](diffhunk://#diff-8d31d8c50430de6c312cd00676b2fe3698a3af518cc295995df2729ad20e7aafL38-R42) [[2]](diffhunk://#diff-8d31d8c50430de6c312cd00676b2fe3698a3af518cc295995df2729ad20e7aafR70) [[3]](diffhunk://#diff-8d31d8c50430de6c312cd00676b2fe3698a3af518cc295995df2729ad20e7aafR84) [[4]](diffhunk://#diff-8d31d8c50430de6c312cd00676b2fe3698a3af518cc295995df2729ad20e7aafR151)
* [`src/backend/fastapi_app/rag_base.py`](diffhunk://#diff-b7c9457b4c98c0cddcf9bad83c2aa04d755fd868024e1d402122da3876c83423R39): Updated the `get_params` method to include the `seed` parameter.
* [`src/backend/fastapi_app/rag_simple.py`](diffhunk://#diff-a6cde3adf9d68dea70224b84c6b597f6d8d2724e5ade3ed1c87ee2d50b6eca9dR93): Added the `seed` parameter to the `answer` and `answer_stream` methods. [[1]](diffhunk://#diff-a6cde3adf9d68dea70224b84c6b597f6d8d2724e5ade3ed1c87ee2d50b6eca9dR93) [[2]](diffhunk://#diff-a6cde3adf9d68dea70224b84c6b597f6d8d2724e5ade3ed1c87ee2d50b6eca9dR134)

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` manually on my code.
