### PR TITLE
Push results to branch

### DIFF
--- a/.github/workflows/evaluate.yaml
+++ b/.github/workflows/evaluate.yaml
@@ -14,7 +14,10 @@ permissions:
 
 jobs:
   evaluate:
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/evaluate') }}
+    if: |
+      contains('["OWNER", "CONTRIBUTOR", "COLLABORATOR", "MEMBER"]', github.event.comment.author_association) &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/evaluate'
     runs-on: ubuntu-latest
     env:
       UV_SYSTEM_PYTHON: 1
@@ -41,10 +44,6 @@ jobs:
       AZURE_OPENAI_EVAL_DEPLOYMENT: ${{ vars.AZURE_OPENAI_EVAL_DEPLOYMENT }}
       AZURE_OPENAI_EVAL_MODEL: ${{ vars.AZURE_OPENAI_EVAL_MODEL }}
     steps:
-      - name: Check for evaluate hash tag
-        if: contains(github.event.comment.body, '#evaluate')
-        run: |
-          echo "Comment contains #evaluate hashtag"
 
       - name: Comment on pull request
         uses: actions/github-script@v7
@@ -193,3 +192,13 @@ jobs:
               repo: context.repo.repo,
               body: `${summary}\n\n[Check the workflow run for more details](${actionsUrl}).`
             })
+
+      - name: Commit and push eval results
+        if: ${{ success() }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout ${{ github.head_ref }}
+          git add evals/results/pr${{ github.event.issue.number }}
+          git commit -m "Add evaluation results for PR #${{ github.event.issue.number }}"
+          git push


### PR DESCRIPTION
## Purpose

This pull request includes updates to the GitHub Actions workflow to enhance the evaluation process for pull requests. Key changes include modifying the conditions under which the evaluation job runs, removing an unnecessary step, and adding a new step to commit and push evaluation results.

Changes to evaluation conditions and steps:

* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405L17-R20): Updated the `if` condition to ensure only authorized users can trigger the evaluation by checking the `author_association` and matching the comment body to `/evaluate`.
* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405L44-L47): Removed the step that checks for the `#evaluate` hashtag in the comment body, as it is no longer necessary.

New step to commit and push results:

* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405R195-R204): Added a step to commit and push evaluation results if the workflow runs successfully. This includes configuring Git, checking out the branch, adding the results, committing with a message, and pushing the changes.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A