### PR TITLE
Use a different way to push results in eval workflow

### DIFF
--- a/.github/workflows/evaluate.yaml
+++ b/.github/workflows/evaluate.yaml
@@ -56,7 +56,7 @@ jobs:
               body: "Starting evaluation! Check the Actions tab for progress, or wait for a comment with the results."
             })
 
-      - name: Checkout pull request 🏁
+      - name: Checkout pull request
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head

--- a/.github/workflows/evaluate.yaml
+++ b/.github/workflows/evaluate.yaml
@@ -58,8 +58,11 @@ jobs:
 
       - name: Checkout pull request
         uses: actions/checkout@v4
-        with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Checkout Pull Request
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pgvector
         run: |
@@ -193,25 +196,11 @@ jobs:
               body: `${summary}\n\n[Check the workflow run for more details](${actionsUrl}).`
             })
 
-      - name: Get PR branch name
-        id: get_pr_branch
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.issue.number;
-            const { data: pr } = await github.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: prNumber
-            });
-            return { branch: pr.head.ref };
-
       - name: Commit and push eval results
         if: ${{ success() }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b temp-branch
           git add evals/results/pr${{ github.event.issue.number }}
           git commit -m "Add evaluation results for PR #${{ github.event.issue.number }}"
-          git push origin temp-branch:${{ steps.get_pr_branch.outputs.branch }}
+          git push


### PR DESCRIPTION
## Purpose

This pull request includes updates to the GitHub Actions workflow configuration to streamline the checkout and commit processes.

Changes to workflow configuration:

* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405L59-R65): Updated the step to checkout the pull request using the `hub` command and environment variables for better integration with GitHub Actions.
* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405L196-R206): Removed the step to get the PR branch name and simplified the commit and push process.


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` manually on my code.
