### PR TITLE
Use gh cli instead of hub

### DIFF
--- a/.github/workflows/evaluate.yaml
+++ b/.github/workflows/evaluate.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout actual pull request
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/evaluate.yaml
+++ b/.github/workflows/evaluate.yaml
@@ -56,10 +56,10 @@ jobs:
               body: "Starting evaluation! Check the Actions tab for progress, or wait for a comment with the results."
             })
 
-      - name: Checkout pull request
+      - name: Checkout default branch
         uses: actions/checkout@v4
 
-      - name: Checkout Pull Request
+      - name: Checkout actual pull request
         run: hub pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Purpose

This pull request includes changes to the `.github/workflows/evaluate.yaml` file to improve the workflow for checking out pull requests and the default branch.

Workflow improvements:

* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405L59-R63): Changed the job name from "Checkout pull request" to "Checkout default branch" and updated the action to `actions/checkout@v4`.
* [`.github/workflows/evaluate.yaml`](diffhunk://#diff-c13bb9112390fbf0c4f2fd7cafeed0357996509af5da617df205c035d6c04405L59-R63): Updated the step to check out the actual pull request using `gh pr checkout` instead of `hub pr checkout`.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` manually on my code.
