### PR TITLE
Update HNSW indexes to use cosine operator

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -73,7 +73,7 @@ jobs:
           if: matrix.os == 'ubuntu-latest'
           run: |
             sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
-            sudo apt-get install postgresql-14-pgvector
+            sudo apt-get install postgresql-16-pgvector
             sudo systemctl start postgresql
             sudo -u postgres psql -c "ALTER USER ${{ env.POSTGRES_USERNAME }} PASSWORD '${{ env.POSTGRES_PASSWORD }}'"
             sudo -u postgres psql -c 'CREATE EXTENSION vector'

--- a/src/backend/fastapi_app/postgres_models.py
+++ b/src/backend/fastapi_app/postgres_models.py
@@ -39,23 +39,30 @@ class Item(Base):
         return f"Name: {self.name} Description: {self.description} Type: {self.type}"
 
 
-# Define HNSW index to support vector similarity search
-# Use the vector_ip_ops access method (inner product) since these embeddings are normalized
+"""
+**Define HNSW index to support vector similarity search**
+
+We use the vector_cosine_ops access method (cosine distance)
+ since it works for both normalized and non-normalized vector embeddings
+If you know your embeddings are normalized,
+ you can switch to inner product for potentially better performance.
+The index operator should match the operator used in queries.
+"""
 
 table_name = Item.__tablename__
 
 index_ada002 = Index(
-    "hnsw_index_for_innerproduct_{table_name}_embedding_ada002",
+    "hnsw_index_for_cosine_{table_name}_embedding_ada002",
     Item.embedding_ada002,
     postgresql_using="hnsw",
     postgresql_with={"m": 16, "ef_construction": 64},
-    postgresql_ops={"embedding_ada002": "vector_ip_ops"},
+    postgresql_ops={"embedding_ada002": "vector_cosine_ops"},
 )
 
 index_nomic = Index(
-    f"hnsw_index_for_innerproduct_{table_name}_embedding_nomic",
+    f"hnsw_index_for_cosine_{table_name}_embedding_nomic",
     Item.embedding_nomic,
     postgresql_using="hnsw",
     postgresql_with={"m": 16, "ef_construction": 64},
-    postgresql_ops={"embedding_nomic": "vector_ip_ops"},
+    postgresql_ops={"embedding_nomic": "vector_cosine_ops"},
 )


### PR DESCRIPTION
## Purpose

Fixes #152 

This PR updates the indexes to use the same operator used in the queries.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [x] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [x] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [x] I ran `python -m mypy` to check for type errors
- [x] I either used the pre-commit hooks or ran `ruff` manually on my code.
