### PR TITLE
Make references collapsible, collapse by default

### DIFF
--- a/src/frontend/src/components/Answer/Answer.tsx
+++ b/src/frontend/src/components/Answer/Answer.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Stack, IconButton } from "@fluentui/react";
 import DOMPurify from "dompurify";
 
@@ -29,6 +29,7 @@ export const Answer = ({
     onFollowupQuestionClicked,
     showFollowupQuestions
 }: Props) => {
+    const [isReferencesCollapsed, setIsReferencesCollapsed] = useState(true);
     const followupQuestions = answer.context.followup_questions;
     const messageContent = answer.message.content;
     const parsedAnswer = useMemo(() => parseAnswerToHtml(messageContent, isStreaming, onCitationClicked), [answer]);
@@ -60,22 +61,32 @@ export const Answer = ({
             {!!parsedAnswer.citations.length && (
                 <Stack.Item>
                     <Stack horizontal wrap tokens={{ childrenGap: 5 }}>
-                        <span className={styles.citationLearnMore}>References:</span>
-                        <ol>
-                        {parsedAnswer.citations.map((rowId, ind) => {
-                            const citation = answer.context.data_points[rowId];
-                            if (!citation) return null;
-                            return (
-                                <li key={rowId}>
-                                    <h4>{citation.name}</h4>
-                                    <p className={styles.referenceMetadata}>Brand: {citation.brand}</p>
-                                    <p className={styles.referenceMetadata}>Price: {citation.price}</p>
-                                    <p>{citation.description}</p>
-                                </li>
-                            );
-                        })}
-                        </ol>
+                        <Stack horizontal verticalAlign="center" tokens={{ childrenGap: 5 }}>
+                            <IconButton
+                                iconProps={{ iconName: isReferencesCollapsed ? "ChevronDown" : "ChevronUp" }}
+                                title={isReferencesCollapsed ? "Expand references" : "Collapse references"}
+                                ariaLabel={isReferencesCollapsed ? "Expand references" : "Collapse references"}
+                                onClick={() => setIsReferencesCollapsed(!isReferencesCollapsed)}
+                            />
+                            <span className={styles.citationLearnMore}>References:</span>
+                        </Stack>
                     </Stack>
+                    {!isReferencesCollapsed && (
+                        <ol>
+                            {parsedAnswer.citations.map((rowId, ind) => {
+                                const citation = answer.context.data_points[rowId];
+                                if (!citation) return null;
+                                return (
+                                    <li key={rowId}>
+                                        <h4>{citation.name}</h4>
+                                        <p className={styles.referenceMetadata}>Brand: {citation.brand}</p>
+                                        <p className={styles.referenceMetadata}>Price: {citation.price}</p>
+                                        <p>{citation.description}</p>
+                                    </li>
+                                );
+                            })}
+                        </ol>
+                    )}
                 </Stack.Item>
             )}
 


### PR DESCRIPTION
## Purpose

Better user experience

<img width="1165" alt="Screenshot 2025-05-11 at 12 40 54 PM" src="https://github.com/user-attachments/assets/4ce9949b-29e1-42e5-bd31-0cf6946023d6" />


## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

- [ ] The current tests all pass (`python -m pytest`).
- [ ] I added tests that prove my fix is effective or that my feature works
- [ ] I ran `python -m pytest --cov` to verify 100% coverage of added lines
- [ ] I ran `python -m mypy` to check for type errors
- [ ] I either used the pre-commit hooks or ran `ruff` manually on my code.
