### PR TITLE
Restrict regions due to AppInsights error

### DIFF
--- a/.github/workflows/app-tests.yaml
+++ b/.github/workflows/app-tests.yaml
@@ -59,12 +59,12 @@ jobs:
           run: |
               call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
               cd %TEMP%
-              git clone --branch v0.7.4 https://github.com/pgvector/pgvector.git
+              git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
               cd pgvector
               nmake /NOLOGO /F Makefile.win
               nmake /NOLOGO /F Makefile.win install
-              sc config postgresql-x64-14 start=auto
-              net start postgresql-x64-14
+              sc config postgresql-x64-17 start=auto
+              net start postgresql-x64-17
               "%PGBIN%/psql" -d postgres -c "CREATE EXTENSION vector"
 
         - name: (Linux) Install pgvector and set password

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,6 +7,66 @@ param name string
 
 @minLength(1)
 @description('Primary location for all resources')
+// microsoft.insights/components has restricted regions
+@allowed([
+  'eastus'
+  'southcentralus'
+  'northeurope'
+  'westeurope'
+  'southeastasia'
+  'westus2'
+  'uksouth'
+  'canadacentral'
+  'centralindia'
+  'japaneast'
+  'australiaeast'
+  'koreacentral'
+  'francecentral'
+  'centralus'
+  'eastus2'
+  'eastasia'
+  'westus'
+  'southafricanorth'
+  'northcentralus'
+  'brazilsouth'
+  'switzerlandnorth'
+  'norwayeast'
+  'norwaywest'
+  'australiasoutheast'
+  'australiacentral2'
+  'germanywestcentral'
+  'switzerlandwest'
+  'uaecentral'
+  'ukwest'
+  'japanwest'
+  'brazilsoutheast'
+  'uaenorth'
+  'australiacentral'
+  'southindia'
+  'westus3'
+  'koreasouth'
+  'swedencentral'
+  'canadaeast'
+  'jioindiacentral'
+  'jioindiawest'
+  'qatarcentral'
+  'southafricawest'
+  'germanynorth'
+  'polandcentral'
+  'israelcentral'
+  'italynorth'
+  'mexicocentral'
+  'spaincentral'
+  'newzealandnorth'
+  'chilecentral'
+  'indonesiacentral'
+  'malaysiawest'
+])
+@metadata({
+  azd: {
+    type: 'location'
+  }
+})
 param location string
 
 @description('Whether the deployment is running on GitHub Actions')


### PR DESCRIPTION
## Purpose

This pull request updates the `location` parameter in the `infra/main.bicep` file to restrict allowed deployment regions and add relevant metadata. The main change ensures that deployments can only be performed in regions supported by `microsoft.insights/components`.

Resource region restrictions:

* Added an `@allowed` decorator to the `location` parameter, listing all supported Azure regions for `microsoft.insights/components`. This prevents deployments in unsupported regions.
* Added an `@metadata` decorator to the `location` parameter to specify its type as 'location' for azd.

## Does this introduce a breaking change?

When developers merge from main and run the server, azd up, or azd deploy, will this produce an error?
If you're not sure, try it out on an old environment.

```
[ ] Yes
[X] No
```

## Type of change

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Code quality checklist

See [CONTRIBUTING.md](https://github.com/Azure-Samples/rag-postgres-openai-python/blob/main/CONTRIBUTING.md#submit-pr) for more details.

N/A