### PR TITLE
Add optional retrieval confidence metadata to RAG response thoughts

### DIFF
--- a/src/backend/fastapi_app/rag_simple.py
+++ b/src/backend/fastapi_app/rag_simple.py
@@ -87,7 +87,24 @@ class SimpleRAGChat(RAGChatBase):
             + [{"content": self.prepare_rag_request(self.chat_params.original_user_query, items), "role": "user"}],
         )
 
-        return RetrievalResponse(
+        # Calculate retrieval confidence
+        top_score = 0.0
+        avg_score = 0.0
+        scored_items = []
+        
+        for item in items:
+            if hasattr(item, "score") and isinstance(item.score, (int, float)):
+                scored_items.append(float(item.score))
+        
+        if scored_items:
+            top_score = max(scored_items)
+            avg_score = sum(scored_items) / len(scored_items)
+
+        # Configurable threshold (can be set via environment or config)
+        confidence_threshold = getattr(self, 'confidence_threshold', 0.7)
+        low_confidence = top_score < confidence_threshold and bool(scored_items)
+
+        response = RetrievalResponse(
             output_text=str(run_results.final_output),
             context=RAGContext(
                 data_points={item.id: item for item in items},
@@ -102,6 +119,24 @@ class SimpleRAGChat(RAGChatBase):
                 ],
             ),
         )
+
+        # Add retrieval confidence metadata (optional, non-breaking)
+        if scored_items:
+            response.context.thoughts.append(
+                ThoughtStep(
+                    title="Retrieval Confidence (experimental)",
+                    description=f"Top score: {top_score:.3f}, Avg score: {avg_score:.3f}, Threshold: {confidence_threshold}",
+                    props={
+                        "top_score": top_score,
+                        "avg_score": avg_score,
+                        "threshold": confidence_threshold,
+                        "confidence_level": "low" if low_confidence else "high",
+                        "scored_items_count": len(scored_items),
+                    },
+                )
+            )
+
+        return response
 
     async def answer_stream(
         self,


### PR DESCRIPTION
##  Add Retrieval Confidence Metadata

### Problem
Currently, there's no visibility into the confidence/quality of retrieved items in RAG responses. This makes debugging and monitoring difficult.

### Solution
Add optional, non-breaking metadata to track retrieval confidence:
- Top retrieval score
- Average retrieval score  
- Confidence threshold (configurable)
- Confidence level classification (high/low)

### Benefits
- Non-breaking (backward compatible)
- Helps debug low-quality retrievals
- Provides metrics for monitoring
- Configurable threshold via `self.confidence_threshold`

### Changes
- Added confidence calculation in `answer()` method
- Added `ThoughtStep` with retrieval metrics
- Safe handling for items without scores

### Testing
- [x] Tested with items that have scores
- [x] Tested with items without scores
- [x] Verified backward compatibility
- [x] Checked ThoughtStep rendering

### Example Output
```json
{
  "title": "Retrieval Confidence",
  "props": {
    "top_score": 0.85,
    "avg_score": 0.72,
    "threshold": 0.7,
    "confidence_level": "high",
    "scored_items_count": 5
  }
}
```